### PR TITLE
scan header add

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 2) <b>-n</b> flag specifies the number of threads to use
 3) <b>-sf</b> list of terms to search for in each scan header/filter. Scans that contain these words are ommited
 4) <b>-o</b> path to folder where the converted files will be saved
-5) **-sh** flag specified whether to parse `scanHeader` for each scan. Default is `False`
+5) **-sh** optional flag specified whether to parse `scanHeader` for each scan. Default is `False`, or use `--no-scan-header`.
 
 ###### Install Dependencies
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
  |precursorMZ         |Float32|Precursor MZ or the center of the isolation window for an MSN scan <br> If no precursor was assigned. Missing for an MS1 scan.
  |precursorCharge     |Int32|Precursor charge
  |msOrder             |Int32|As in MS1, MS2, or MSN scan. Is "2" for an MS2 scan. 
+ |scanHeader | MapArray{(utf8,utf8)} | Map Array of key-values of each scan header field for each scan.
 
  # Usage
  
@@ -34,13 +35,11 @@
 2) <b>-n</b> flag specifies the number of threads to use
 3) <b>-sf</b> list of terms to search for in each scan header/filter. Scans that contain these words are ommited
 4) <b>-o</b> path to folder where the converted files will be saved
+5) **-sh** flag specified whether to parse `scanHeader` for each scan. Default is `False`
 
 ###### Install Dependencies
 ```
-pip install pythonnet
-pip install tqdm
-pip install pyarrow
-pip install psutil
+pip install -r requirements.txt
 ```
 ###### POSIX
 ```
@@ -66,7 +65,8 @@ display(json_args)
  'thermo_dlls': '../libs',
  'scan_filter_regex_list': ['ITMS', 'kazoo'],
  'num_workers': 12,
- 'parquet_out': './parquet_out'}
+ 'parquet_out': './parquet_out',
+ 'scan_header_used': true}
 ```
 
 ## Convert *.raw files using .json arguments

--- a/args.json
+++ b/args.json
@@ -1,1 +1,1 @@
-{"raw_dir": "/Volumes/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch2/Hela_iAPI_Segmentation_TwoThousandth4.raw", "thermo_dlls": "libs", "scan_filter_regex_list": ["ITMS"], "num_workers": 4, "parquet_out": "out/", "scan_header_used": true}
+{"raw_dir": "/Volumes/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch2/Hela_iAPI_Segmentation_TwoThousandth4.raw", "thermo_dlls": "libs", "scan_filter_regex_list": ["ITMS"], "num_workers": 4, "parquet_out": "out/", "scan_header_used": false}

--- a/args.json
+++ b/args.json
@@ -1,1 +1,1 @@
-{"raw_dir": "/Volumes/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch2/Hela_iAPI_Segmentation_TwoThousandth4.raw", "thermo_dlls": "libs/", "scan_filter_regex_list": ["msx"], "num_workers": 1, "parquet_out": "/Users/anh.h.nguyen/ThermoRawFileToParquetConverter", "scan_header_used": true}
+{"raw_dir": "/Volumes/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch2/Hela_iAPI_Segmentation_TwoThousandth4.raw", "thermo_dlls": "libs", "scan_filter_regex_list": ["ITMS"], "num_workers": 4, "parquet_out": "out/", "scan_header_used": true}

--- a/args.json
+++ b/args.json
@@ -1,1 +1,1 @@
-{"raw_dir": "../raw", "thermo_dlls": "../libs", "scan_filter_regex_list": ["ITMS", "kazoo"], "num_workers": 12, "parquet_out": "./parquet_out"}
+{"raw_dir": "/Volumes/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch2/Hela_iAPI_Segmentation_TwoThousandth4.raw", "thermo_dlls": "libs/", "scan_filter_regex_list": ["msx"], "num_workers": 1, "parquet_out": "/Users/anh.h.nguyen/ThermoRawFileToParquetConverter", "scan_header_used": true}

--- a/raw_to_parquet.py
+++ b/raw_to_parquet.py
@@ -70,10 +70,10 @@ def parseArguments():
                         help="number of workers to use", 
                         type=int, 
                         default=4)
-    parser.add_argument("-sh", "--scan-header-used",
+    parser.add_argument("-sh", "--scan-header",
                         help="whether to use scan header for the output",
-                        type = bool,
-                        default = False)
+                        default = False,
+                        action=argparse.BooleanOptionalAction)
 
 
     parser.add_argument
@@ -127,8 +127,8 @@ def printArguments():
     print("Thermo dlls Directory: ", args.thermo_dlls)
     print("Scan Filter Regex List: ", args.scan_filter_regex_list)
     global SCAN_HEADER_USED
-    SCAN_HEADER_USED = args.scan_header_used
-    print("Scan Header Used: ", args.scan_header_used)
+    SCAN_HEADER_USED = args.scan_header
+    print("Scan Header Used: ", args.scan_header)
     print("Number of Workers: ", args.num_workers)
     print("Parquet File Output Folder: ", args.parquet_out)
     return 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pythonnet==3.0.1
+tqdm==4.65.0
+pyarrow==12.0.1
+psutil==5.9.5
+numpy==1.24.4


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR covers adding a feature to parse all of the scan header fields of the raw file with CLI support. The apache arrow format now has a new field called `scanHeader` with `MapArray` type. See artefact. Right now I only map it as key-value as a tuple of strings. Possibly in the future, we might need to specify data types. For example, it makes sense for `Scan Description` to be string but maybe `Multi Inject Info` to be an array.

Also put dependency into a requirements txt file

## Artefact 
None. Example output

```
$ loaded_arrays['scanHeader'][215]
<pyarrow.MapScalar: [('Scan Description', 'lp_203'), ('AGC', 'Predicted'), ('Micro Scan Count', '1'), ('Ion Injection Time (ms)', '3.2094132900238037'), ('Elapsed Scan Time (sec)', '0.49274277687072754'), ('Average Scan by Inst', 'False'), ...]>
```


## Related Tickets & Documents
None


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No
