### PR TITLE
Typo Fixed and Works on LSF 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,5 @@ Arrow Format
             with pa.RecordBatchFileWriter(file, self.__PaTable__.schema) as writer:
                 writer.write_table(self.__PaTable__)
  ```
-4) Needs to be tested on Windows. The only errors at present should have to do with file path compatability. Should be possible to fix this without too much trouble. 
+4) Needs to be tested on Windows. The only errors at present should have to do with file path compatability. Should be possible to fix this without too much trouble.
+5) Test on Linux (CentOS). It seems like there is problem with multithreading with mono runtime as of now Sept 2023. See https://github.com/mono/mono/issues/18356. So need to explicitly state `spawn` when parallelizing.

--- a/raw_to_parquet.py
+++ b/raw_to_parquet.py
@@ -103,7 +103,7 @@ if args.raw_dir.split('.')[-1] == "json":
         args.scan_filter_regex_list = json_args['scan_filter_regex_list']
         args.num_workers = json_args['num_workers']
         args.parquet_out= json_args['parquet_out']
-        args.scan_header_used = json_args['scan_header_used']
+        args.scan_header = json_args['scan_header_used']
     except:
         print("Could not convert json_args to properly formated arguments")
 else:
@@ -117,7 +117,7 @@ else:
                  'scan_filter_regex_list': args.scan_filter_regex_list,
                  'num_workers': args.num_workers,
                  'parquet_out': args.parquet_out,
-                 'scan_header_used': args.scan_header_used           
+                 'scan_header': args.scan_header           
                 }
         json.dump(json_args, outfile)
 

--- a/raw_to_parquet.py
+++ b/raw_to_parquet.py
@@ -482,7 +482,7 @@ def main():
     #Convert raw files in parallel
     from itertools import repeat
     import multiprocessing as mp
-    mp.set_start_method("fork") # Use spawn instead of fork cause MONO complains
+    mp.set_start_method("spawn") # Use spawn instead of fork cause MONO complains
     with mp.Pool(args.num_workers) as pool: 
         arguments = zip(raw_file_paths, repeat(scan_filters), repeat(parquet_out), repeat(SCAN_HEADER_USED))
         pool.starmap(convertRawFile, arguments)

--- a/raw_to_parquet.py
+++ b/raw_to_parquet.py
@@ -117,7 +117,7 @@ else:
                  'scan_filter_regex_list': args.scan_filter_regex_list,
                  'num_workers': args.num_workers,
                  'parquet_out': args.parquet_out,
-                 'scan_header': args.scan_header           
+                 'scan_header_used': args.scan_header           
                 }
         json.dump(json_args, outfile)
 
@@ -482,17 +482,20 @@ def main():
     #Convert raw files in parallel
     from itertools import repeat
     import multiprocessing as mp
+    mp.set_start_method("fork") # Use spawn instead of fork cause MONO complains
     with mp.Pool(args.num_workers) as pool: 
         arguments = zip(raw_file_paths, repeat(scan_filters), repeat(parquet_out), repeat(SCAN_HEADER_USED))
         pool.starmap(convertRawFile, arguments)
-
+    pool.join()
+    #convertRawFile("/storage1/fs1/d.goldfarb/Active/RIS_Goldfarb_Lab/Anh/ms1_dw/batch5/",
+    #"", "/out", True)
     #Time for converting all files
     print("Converted " + str(len(raw_file_paths)) + " raw files in " + str((time.time() - initial)/60) + " minutes")
 
     print("Memory in use (MB): ")
     #############
     #WARNING! DO NOT REMOVE THE FOLLOWING LINE OF CODE!
-    #ON MAC OS, REMOVING "import psutil" CAUSES A SEGV ERROR IN 
+    #ON MAC OS, REMOVING "import psutil" CAUSES #A SEGV ERROR IN 
     #THE MONO RUNTIME. PART OF THE ERROR MESSAGE IS PASTED BELOW. 
     #############
     #PART OF THE ERROR RECIEVED IF YOU REMOVE "import psutil"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

There is a typo in the scan header argument. My bad. Also I tried to test it on LSF (CentOS) and it complains that can't replicate mono runtime resources. See artifact. My resolution is explicitly to set the multiprocessing method to spawn instead of forking and that solves it. Test both on lsf and local and both doesn't break


## Artefact 

Error trying to fork resources 

```
Pkilling 0x139896906868544x from 0x139896889571072x
Could not exec mono-hang-watchdog, expected on path '/etc/../bin/mono-hang-watchdog' (errno 2)
Pkilling 0x139896906868544x from 0x139896889571072x
Pkilling 0x139896906868544x from 0x139896889571072x
Could not exec mono-hang-watchdog, expected on path '/etc/../bin/mono-hang-watchdog' (errno 2)
Could not exec mono-hang-watchdog, expected on path '/etc/../bin/mono-hang-watchdog' (errno 2)
Pkilling 0x139896906868544x from 0x139896889571072x
Could not exec mono-hang-watchdog, expected on path '/etc/../bin/mono-hang-watchdog' (errno 2)
Pkilling 0x139896906868544x from 0x139896889571072x
Could not exec mono-hang-watchdog, expected on path '/etc/../bin/mono-hang-watchdog' (errno 2)
* Assertion at exceptions-amd64.c:906, condition `jit_tls' not met
Pkilling 0x139896906868544x from 0x139896889571072x
```

Python traceback:

```
Process ForkPoolWorker-12:
Process ForkPoolWorker-11:
Process ForkPoolWorker-10:
Process ForkPoolWorker-8:
Process ForkPoolWorker-7:
Process ForkPoolWorker-9:
Traceback (most recent call last):
  File "ThermoRawFileToParquetConverter/raw_to_parquet.py", line 515, in <module>
    sys.exit(main())
             ^^^^^^
  File "ThermoRawFileToParquetConverter/raw_to_parquet.py", line 488, in main
    pool.starmap(convertRawFile, arguments)
  File "/usr/local/lib/python3.11/multiprocessing/pool.py", line 375, in starmap
    return self._map_async(func, iterable, starmapstar, chunksize).get()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/multiprocessing/pool.py", line 768, in get
    self.wait(timeout)
  File "/usr/local/lib/python3.11/multiprocessing/pool.py", line 765, in wait
    self._event.wait(timeout)
  File "/usr/local/lib/python3.11/threading.py", line 622, in wait
    signaled = self._cond.wait(timeout)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/threading.py", line 320, in wait
    waiter.acquire()
```

## Related Tickets & Documents
None


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [x] 📜 README.md
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

No

